### PR TITLE
Comment prop filter for Width, Height, Acq Start, Acq Stop to enable …

### DIFF
--- a/gst-libs/gst/pylon/gstpylonfeaturewalker.cpp
+++ b/gst-libs/gst/pylon/gstpylonfeaturewalker.cpp
@@ -58,14 +58,14 @@ std::vector<GParamSpec*> gst_pylon_camera_handle_node(
     GenApi::INode* node, GstPylonParamFactory& param_factory);
 
 static const std::unordered_set<std::string> propfilter_set = {
-    "Width",
-    "Height",
+    //"Width",
+    //"Height",
     "PixelFormat",
     "AcquisitionFrameRateEnable",
     "AcquisitionFrameRate",
     "AcquisitionFrameRateAbs",
-    "AcquisitionStart",
-    "AcquisitionStop",
+    //"AcquisitionStart",
+    //"AcquisitionStop",
     "UserSetLoad",
     "UserSetSave",
     "TriggerSoftware",


### PR DESCRIPTION
These settings are needed to set the OffsetX and Y settings.
This was tested with the following command line: GST_DEBUG=4 gst-launch-1.0 pylonsrc cam::Width=400 cam::Height=400 cam::OffsetX=500 cam::OffsetY=0 cam::ExposureAuto=2 ! "video/x-raw,format=YUY2,width=1200,height=1200" ! videoconvert ! queue ! autovideosink